### PR TITLE
Fix podspec lint warning

### DIFF
--- a/LTSupportAutomotive.podspec
+++ b/LTSupportAutomotive.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage         = "https://github.com/mickeyl/LTSupportAutomotive"
   s.license          = { :type => "MIT" }
   s.authors          = { "Dr. Michael Lauer" => "mickey@vanille.de" }
-  s.source           = { :git => "https://github.com/mickeyl/LTSupportAutomotive", :branch => "master" }
+  s.source           = { :git => "https://github.com/mickeyl/LTSupportAutomotive.git", :branch => "master" }
 
   s.platform     = :ios, "9.0"
   s.requires_arc = true


### PR DESCRIPTION
I should have run the linter again - there was a typo in the podspec file (missing .git repository suffix).

If this is merged, you could create a new release by tagging the current code, and updating the podspec to use this new tag:
```
s.source = { :git => "https://github.com/mickeyl/LTSupportAutomotive.git", :tag => "1.0.0" }
```

Then you could upload the podspec to the CocoaPods repo, and everybody can use this released version in a podfile.
```
pod trunk push LTSupportAutomotive.podspec
```