### PR TITLE
Update README.md - replace vgate with scantool - vgate violate freedom

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ I have tested this library myself with the following adapters (Note that none of
 * FIXD OBD-II Scan Tool (2nd Gen)
 * kungfuren OBD2 Bluetooth 4.0
 * LELink Bluetooth Low Energy
-* VGate iCar Pro BLE4.0 Dual
+* SCANTOOL OBDLINK CX
 * WGSoft.de UniCarScan UCSI-2000
 * WGSoft.de UniCarScan UCSI-2100
 


### PR DESCRIPTION
Vgate is a company that seal OpenSource software, add advertisement to it and then release it under closed source licence. They should not be advertised in any opensource project. Instead add the BLE 5.1 based OBDLINK CX. More about this here: https://github.com/fr3ts0n/AndrOBD/issues/207